### PR TITLE
Search for ssh-studio-resources.gresource in /usr/share too

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -110,6 +110,7 @@ class SSHConfigStudioApp(Adw.Application):
                 ),
                 "/opt/homebrew/share/io.github.BuddySirJava.SSH-Studio/ssh-studio-resources.gresource",
                 "/usr/local/share/io.github.BuddySirJava.SSH-Studio/ssh-studio-resources.gresource",
+                "/usr/share/io.github.BuddySirJava.SSH-Studio/ssh-studio-resources.gresource",
                 "data/ssh-studio-resources.gresource",
             ]
             for candidate in resource_candidates:


### PR DESCRIPTION
If you install SSH-Studio with a package system, you will normally use /usr/ directly instead of /usr/local/. This change avoids having to create a [specific patch when packaging SSH-Studio](https://aur.archlinux.org/cgit/aur.git/tree/ssh-studio-gresource.patch?h=ssh-studio).