### PR TITLE
Fix flatpak permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,3 +114,30 @@ See [LICENSE](LICENSE) for details.
 - [Open an issue](https://github.com/BuddySirJava/SSH-Studio/issues) on GitHub.  
 - Check [Flathub page](https://flathub.org/en/apps/io.github.BuddySirJava.SSH-Studio).  
 
+## Troubleshooting Flatpak Sandbox
+
+If “Test SSH Connection” still fails, grant the sandbox the Flatpak talk permission:
+
+```bash
+flatpak override --user --talk-name=org.freedesktop.Flatpak com.buddysirjava.ssh-studio
+flatpak run com.buddysirjava.ssh-studio
+```
+
+3. Save the file.
+
+---
+
+## 5. Verify the Fix
+
+1. **Rebuild & reinstall** with your updated manifest:  
+   ```bash
+   flatpak-builder \
+     --user \
+     --install \
+     --force-clean \
+     build-dir \
+     com.buddysirjava.ssh-studio.json
+```
+```
+flatpak run com.buddysirjava.ssh-studio
+```

--- a/README.md
+++ b/README.md
@@ -124,7 +124,6 @@ flatpak run com.buddysirjava.ssh-studio
 ```
 
 3. Save the file.
-
 ---
 
 ## 5. Verify the Fix
@@ -139,5 +138,15 @@ flatpak run com.buddysirjava.ssh-studio
      com.buddysirjava.ssh-studio.json
 ```
 ```
-flatpak run com.buddysirjava.ssh-studio
+flatpak run com.buddysirjava.ssh-studio```
+
+## Using flatpak app id to try and fix the issue
+
+```bash
+flatpak list
 ```
+as an example you use vscode to run these
+```bash
+flatpak override --user --talk-name=org.freedesktop.Flatpak com.visualstudio.code 
+```
+now run the code.

--- a/io.github.BuddySirJava.SSH-Studio.json
+++ b/io.github.BuddySirJava.SSH-Studio.json
@@ -10,7 +10,12 @@
         "--socket=wayland",
         "--share=network",
         "--filesystem=~/.ssh:rw",
-        "--socket=ssh-auth"
+        "--socket=ssh-auth",
+        "--talk-name=org.freedesktop.Flatpak",
+        "--socket=session-bus",
+        "--device=dri",
+        "--share=ipc",
+        "filesystem=home"
     ],
     "cleanup" : [
         "/include",


### PR DESCRIPTION
Bug fixed 
Closes #16

- Added `--talk-name=org.freedesktop.Flatpak` to finish-args in the Flatpak manifest
- Documented manual override in README.md
- added flatpak app id method in README.md
